### PR TITLE
Composer binary usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,26 @@ vex is a small PHP app that sends some load to a web application
 
 Download the latest release from GitHub [Releases](https://github.com/vamsiikrishna/vex/releases).
 
-
-
-
-
 ## Usage
 
-Usage:
-``  vex [options] [--] <url> [<n>] [<c>]
- ``
+Usage:  
+`vex [options] [--] <url> [<n>] [<c>]`
 
-Arguments:
+Arguments:  
 ```
   url                      The URL to which the requests should be sent
   n                        Number of requests to be made [default: 1]
   c                        Concurrency [default: 1]
 ```
-Options:
+
+Options:  
 ```
   -m, --method[=METHOD]    HTTP Method [default: "GET"]
   -H, --headers[=HEADERS]  Headers (multiple values allowed)
   -d, --body[=BODY]        Request body
 ```
-Example :
+
+Example:  
 
 - 1000 Get requests with 10 concurrency to `http://127.0.0.1:8000`
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ vex is a small PHP app that sends some load to a web application
 
 Download the latest release from GitHub [Releases](https://github.com/vamsiikrishna/vex/releases).
 
+Or require globally using Composer with `composer global require vamsiikrishna/vex`. This will automatically add the `vex` binary to your path.
+
 ## Usage
 
 Usage:  

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "vamsiikrishna/vex",
-  "description": "small app that sends some load to a web application.",
+  "description": "A small app that sends some load to a web application.",
   "type": "project",
   "require": {
     "guzzlehttp/guzzle": "~6.0",
@@ -18,5 +18,8 @@
       "name": "Vamsi Krishna B",
       "email": "vamsi@fastmail.com"
     }
+  ],
+  "bin": [
+    "bin/vex"
   ]
 }


### PR DESCRIPTION
I've tidied up the [`README`][readme] a little.

This change is based on using the Composer [`bin`][binaries] array, and would make the package compliant with a package host such as [Packagist][packagist].

Pretty much all I've done is made it so that you'd be able to import it into Packagist, so that if someone runs `composer global require vamsiikrishna/vex` it would add the binary to the path. People would still be able to download the packaged PHAR file, but it would give another option to people who prefer to be able to just run a `composer global update` to install updates.

This update does rely on adding this to a package host such as [Packagist] though.

Completely up to you, and if you'd like to decline this, that's fine.

[binaries]: https://getcomposer.org/doc/articles/vendor-binaries.md
[packagist]: https://packagist.org
[readme]: https://github.com/PXgamer/vex/blob/1574872cc62f900e0216fe95fa2161b2a979f1ed/README.md