### PR TITLE
Added Composer autoload fix for binary require

### DIFF
--- a/bin/vex
+++ b/bin/vex
@@ -1,6 +1,10 @@
 #!/usr/bin/env php
 <?php
-require __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    require __DIR__ . '/../vendor/autoload.php';
+}
 
 use Symfony\Component\Console\Application;
 use Vamsi\Vex\Command\VexCommand;


### PR DESCRIPTION
I realised that when it's installed using `composer require` it gets symlinked, so the binary needs to check for the `vendor/autoload.php` in 2 locations.

Tested locally using a private package manager and this works.